### PR TITLE
Update workflow (cuda)

### DIFF
--- a/.github/workflows/build-seq.yaml
+++ b/.github/workflows/build-seq.yaml
@@ -1,4 +1,4 @@
-name: BuildBase
+name: BuildBase(Cuda)
 #run-name: ${{ github.actor }} is building base image
 #
 on:
@@ -14,10 +14,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu: [ 20.04, 22.04]
-        cuda: [ 11.8.0, 12.1.1 ]
-        #cuda: [ none, 11.8.0, 12.1.1 ]
-        #cuda: [ none, 11.7.1, 11.8.0, 12.0.1, 12.1.1, 12.2.2 ]
+        include:
+          - ubuntu: 22.04one
+            cuda: 12.1.0-cudnn8
+          #- ubuntu: 22.04one
+          #  cuda: 12.1.1-cudnn8
+          #- ubuntu: 22.04one
+          #  cuda: 12.2.2-cudnn8
+          #- ubuntu: 22.04one
+          #  cuda: 12.3.2-cudnn9
+          #- ubuntu: 22.04one
+          #  cuda: 12.4.1-cudnn
+          #- ubuntu: 22.04one
+          #  cuda: 12.5.1-cudnn
+          #- ubuntu: 22.04one
+          #  cuda: 12.6.3-cudnn
+          #- ubuntu: 22.04one
+          #  cuda: 12.8.1-cudnn
+          #- ubuntu: 24.04one
+          #  cuda: 12.6.3-cudnn
+          #- ubuntu: 24.04one
+          #  cuda: 12.8.1-cudnn
     runs-on: self-hosted
     env:
       IMAGE_NAME: irsl_base
@@ -25,27 +42,45 @@ jobs:
 #      DOCKER_LOCAL: repo.irsl.eiiris.tut.ac.jp/
       DOCKER_DEPLOY: repo.irsl.eiiris.tut.ac.jp/
     steps:
-      - name: Check ROS Version
+      - name: Check Version
         run: |
-          if   [ ${{ matrix.ubuntu }} == 22.04 ]; then
+          if   [ ${{ matrix.ubuntu }} == 24.04one ]; then
+            echo "ROS_DISTRO=one" >> $GITHUB_ENV
+            echo "UBUNTU_VER=24.04" >> $GITHUB_ENV
+          elif [ ${{ matrix.ubuntu }} == 24.04 ]; then
+            echo "ROS_DISTRO=jazzy" >> $GITHUB_ENV
+            echo "UBUNTU_VER=24.04" >> $GITHUB_ENV
+          elif [ ${{ matrix.ubuntu }} == 22.04one ]; then
+            echo "ROS_DISTRO=one" >> $GITHUB_ENV
+            echo "UBUNTU_VER=22.04" >> $GITHUB_ENV
+          elif [ ${{ matrix.ubuntu }} == 22.04 ]; then
             echo "ROS_DISTRO=humble" >> $GITHUB_ENV
+            echo "UBUNTU_VER=22.04" >> $GITHUB_ENV
           elif [ ${{ matrix.ubuntu }} == 20.04 ]; then
             echo "ROS_DISTRO=noetic" >> $GITHUB_ENV
+            echo "UBUNTU_VER=20.04" >> $GITHUB_ENV
           elif [ ${{ matrix.ubuntu }} == 18.04 ]; then
             echo "ROS_DISTRO=melodic" >> $GITHUB_ENV
+            echo "UBUNTU_VER=18.04" >> $GITHUB_ENV
           else
             echo "ROS_DISTRO=none" >> $GITHUB_ENV
           fi
       - name: Make Build Scequence
         run: |
-          if  [ ${{ matrix.cuda }} == none ]; then
-            echo "DOCKER_FILES=Dockerfile.add_glvnd Dockerfile.add_virtualgl Dockerfile.add_entrypoint" >> $GITHUB_ENV
-            echo "INPUT_IMAGE=ros:${{ env.ROS_DISTRO }}-ros-base" >> $GITHUB_ENV
-            echo "OUTPUT_IMAGE=${{ env.DOCKER_DEPLOY }}${{ env.IMAGE_NAME }}:${{ env.ROS_DISTRO }}_opengl" >> $GITHUB_ENV
+          if [ ${{ matrix.cuda }} == "none" ]; then
+            if [ ${{ env.ROS_DISTRO }} == "one" ]; then
+              echo "DOCKER_FILES=Dockerfile.add_glvnd Dockerfile.add_virtualgl Dockerfile.add_one Dockerfile.add_vcs Dockerfile.add_entrypoint" >> $GITHUB_ENV
+              echo "INPUT_IMAGE=ubuntu:${UBUNTU_VER}" >> $GITHUB_ENV
+              echo "OUTPUT_IMAGE=${{ env.DOCKER_DEPLOY }}${{ env.IMAGE_NAME }}:${{ env.ROS_DISTRO }}_opengl" >> $GITHUB_ENV
+            else
+              echo "DOCKER_FILES=Dockerfile.add_glvnd Dockerfile.add_virtualgl    Dockerfile.add_vcs Dockerfile.add_entrypoint" >> $GITHUB_ENV
+              echo "INPUT_IMAGE=ros:${{ env.ROS_DISTRO }}-ros-base" >> $GITHUB_ENV
+              echo "OUTPUT_IMAGE=${{ env.DOCKER_DEPLOY }}${{ env.IMAGE_NAME }}:${{ env.ROS_DISTRO }}_opengl" >> $GITHUB_ENV
+            fi
           else
-            echo "DOCKER_FILES=Dockerfile.add_glvnd Dockerfile.add_virtualgl Dockerfile.add_${{ env.ROS_DISTRO }} Dockerfile.add_entrypoint" >> $GITHUB_ENV
-            echo "INPUT_IMAGE=nvidia/cuda:${{ matrix.cuda }}-cudnn8-devel-ubuntu${{ matrix.ubuntu }}" >> $GITHUB_ENV
-            echo "OUTPUT_IMAGE=${{ env.DOCKER_DEPLOY }}${{ env.IMAGE_NAME }}:${{ env.ROS_DISTRO }}_cuda${{ matrix.cuda }}" >> $GITHUB_ENV
+            echo "DOCKER_FILES=Dockerfile.add_glvnd Dockerfile.add_virtualgl Dockerfile.add_${ROS_DISTRO} Dockerfile.add_vcs Dockerfile.add_entrypoint" >> $GITHUB_ENV
+            echo "INPUT_IMAGE=nvidia/cuda:${{ matrix.cuda }}-devel-ubuntu${UBUNTU_VER}" >> $GITHUB_ENV
+            echo "OUTPUT_IMAGE=${{ env.DOCKER_DEPLOY }}${{ env.IMAGE_NAME }}:cuda_${{ matrix.cuda }}-devel-ubuntu${UBUNTU_VER}_${ROS_DISTRO}" >> $GITHUB_ENV
           fi
       - name: Check out repository code(src)
         uses: actions/checkout@v3
@@ -68,3 +103,4 @@ jobs:
 # cuda + ros
 # input nvidia/cuda:<cuda>-cudnn8-devel-ubuntu<ubuntu>
 # output irsl_base:<ros>_cuda<cuda>
+

--- a/Dockerfile.add_entrypoint
+++ b/Dockerfile.add_entrypoint
@@ -1,7 +1,7 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
 
-LABEL maintainer "IRSL-tut (https://github.com/IRSL-tut) <faculty@irsl.eiiris.tut.ac.jp>"
+LABEL maintainer="IRSL-tut (https://github.com/IRSL-tut) <faculty@irsl.eiiris.tut.ac.jp>"
 
 RUN mkdir -p /ros_home/log && chmod a+rwx /ros_home && chmod a+rwx /ros_home/log
 

--- a/Dockerfile.add_glvnd
+++ b/Dockerfile.add_glvnd
@@ -2,10 +2,10 @@
 ## osrf/ros:melodic-desktop / ros:melodic-robot
 ## melodic/noetic
 ## docker build . --pull -f Dockerfile.add_glvnd --build-arg BASE_IMAGE=ros:melodic-robot -t build_temp/add_glvnd:melodic
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
 
-LABEL maintainer "IRSL-tut (https://github.com/IRSL-tut) <faculty@irsl.eiiris.tut.ac.jp>"
+LABEL maintainer="IRSL-tut (https://github.com/IRSL-tut) <faculty@irsl.eiiris.tut.ac.jp>"
 
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.add_humble
+++ b/Dockerfile.add_humble
@@ -2,7 +2,7 @@
 # This is an auto generated Dockerfile for ros:ros-core
 # generated from docker_images_ros2/create_ros_core_image.Dockerfile.em
 #FROM ubuntu:jammy
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ubuntu:22.04
 FROM ${BASE_IMAGE}
 
 ## TO FIX timezone before here

--- a/Dockerfile.add_noetic
+++ b/Dockerfile.add_noetic
@@ -2,7 +2,7 @@
 # This is an auto generated Dockerfile for ros:ros-core
 # generated from docker_images/create_ros_core_image.Dockerfile.em
 #FROM ubuntu:focal
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ubuntu:20.04
 FROM ${BASE_IMAGE}
 
 ## TO FIX timezone before here

--- a/Dockerfile.add_one
+++ b/Dockerfile.add_one
@@ -2,7 +2,7 @@
 # This is an auto generated Dockerfile for ros:ros-core
 # generated from docker_images/create_ros_core_image.Dockerfile.em
 #FROM ubuntu:focal
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
 
 ## TO FIX timezone before here

--- a/Dockerfile.add_vcs
+++ b/Dockerfile.add_vcs
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
 
 RUN apt-get update -q -qq && apt-get install -q --no-install-recommends -y \

--- a/Dockerfile.add_virtualgl
+++ b/Dockerfile.add_virtualgl
@@ -1,10 +1,10 @@
 ##
 ## docker build . -f Dockerfile.add_virtualgl --build-arg BASE_IMAGE=build_temp/add_glvnd:melodic -t build_temp/add_virtualgl:melodic
 ##
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
 
-LABEL maintainer "IRSL-tut (https://github.com/IRSL-tut) <faculty@irsl.eiiris.tut.ac.jp>"
+LABEL maintainer="IRSL-tut (https://github.com/IRSL-tut) <faculty@irsl.eiiris.tut.ac.jp>"
 
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This pull request includes several changes to the build configuration and Dockerfiles to support new Ubuntu and CUDA versions. The most important changes include updating the build matrix to include new combinations, modifying environment variable assignments, and setting default base images in Dockerfiles.

### Build Configuration Updates:
* [`.github/workflows/build-seq.yaml`](diffhunk://#diff-127ee0a7ed8b05ea574532f7aa4f682e1041db20a85fd78feda68c87f8377c1cL1-R1): Updated the build matrix to include new combinations of Ubuntu 22.04one and CUDA 12.1.0-cudnn8, and modified environment variable assignments to handle new Ubuntu versions. [[1]](diffhunk://#diff-127ee0a7ed8b05ea574532f7aa4f682e1041db20a85fd78feda68c87f8377c1cL1-R1) [[2]](diffhunk://#diff-127ee0a7ed8b05ea574532f7aa4f682e1041db20a85fd78feda68c87f8377c1cL17-R83) [[3]](diffhunk://#diff-127ee0a7ed8b05ea574532f7aa4f682e1041db20a85fd78feda68c87f8377c1cR106)

### Dockerfile Updates:
* `Dockerfile.add_entrypoint`, `Dockerfile.add_glvnd`, `Dockerfile.add_humble`, `Dockerfile.add_noetic`, `Dockerfile.add_one`, `Dockerfile.add_vcs`, `Dockerfile.add_virtualgl`: Set default base images to specific Ubuntu versions (24.04, 22.04, 20.04) and updated maintainer labels to remove spaces around the equal sign. [[1]](diffhunk://#diff-260911f8327a525a658f1bcf419f0824767852c9d4b34d62ef93152d01bc2841L1-R4) [[2]](diffhunk://#diff-c786ca6e67726e32893ad29b84bdb4f6d442877f1d6d5c026f11547ca7df2d8aL5-R8) [[3]](diffhunk://#diff-f20c7ff5a0466733ee7aa8de074be8ae135d45cda8311010aaa8464cf360e8dcL5-R5) [[4]](diffhunk://#diff-98620297c27e1b030ca607c92b2a65913295a8854c89919362e802fb2d3304c2L5-R5) [[5]](diffhunk://#diff-e9ec4e51d4a0df240d0e44cf3b4f4fbb3c6e19f2138979aa01e894bd7dcf13cbL5-R5) [[6]](diffhunk://#diff-6bbe49128b7b2aae6d55427d965427703d402f50e73b88ab47c34e66361c8713L1-R1) [[7]](diffhunk://#diff-06bf8da9211b06c2da112babc078fd736dd08a6c504ce595c992077e6a45ffb5L4-R7)